### PR TITLE
Change filename and GitHub actions creds

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,8 +186,8 @@ async function getMemberActivity(orgid, from, to, contribArray) {
 
     // Prepare path/filename, repo/org context and commit name/email variables
     const reportPath = `reports/${org}-${new Date().toISOString().substring(0, 19).replaceAll(':', '.') + 'Z'}-${fileDate}.csv`
-    const committerName = core.getInput('committer-name', {required: false}) || 'github-actions'
-    const committerEmail = core.getInput('committer-email', {required: false}) || 'github-actions@github.com'
+    const committerName = core.getInput('committer-name', {required: false}) || 'github-actions[bot]'
+    const committerEmail = core.getInput('committer-email', {required: false}) || '41898282+github-actions[bot]@users.noreply.github.com'
     const {owner, repo} = github.context.repo
 
     // Push csv to repo

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ async function getMemberActivity(orgid, from, to, contribArray) {
     })
 
     // Prepare path/filename, repo/org context and commit name/email variables
-    const reportPath = `reports/${org}-${new Date().toISOString().substring(0, 19) + 'Z'}-${fileDate}.csv`
+    const reportPath = `reports/${org}-${new Date().toISOString().substring(0, 19).replaceAll(':', '.') + 'Z'}-${fileDate}.csv`
     const committerName = core.getInput('committer-name', {required: false}) || 'github-actions'
     const committerEmail = core.getInput('committer-email', {required: false}) || 'github-actions@github.com'
     const {owner, repo} = github.context.repo


### PR DESCRIPTION
Fixes:

1. The CSV output file breaks a `git pull` in Windows file system with the following error. This fixes the issue by replacing colons (`':'`) which are illegal characters in Windows filenames with dots (`'.'`) 
> error: invalid path 'reports/OrgName-2023-10-01T10:00:00Z-30-days.csv'


2. Use valid login and email for GitHub Actions Bot as described [here](https://github.com/orgs/community/discussions/26560#discussioncomment-3252339) and [here](https://api.github.com/users/github-actions%5Bbot%5D)

Original PR to base repo: https://github.com/nicklegan/github-org-member-contribution-action/pull/35